### PR TITLE
Backend library split compatibility for January 2025 binary update

### DIFF
--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -43,6 +43,8 @@ namespace LLama.Native
                 
                 foreach (var path in paths)
                 {
+                    Log($"Got relative library path '{path}' from local with {library.Metadata}, trying to load it...", LLamaLogLevel.Debug, config.LogCallback);
+                    
                     // After the llama.cpp binaries have been split up (PR #10256), we need to load the dependencies manually.
                     // It can't be done automatically on Windows, because the dependencies can be in different folders (for example, ggml-cuda.dll from the cuda12 folder, and ggml-cpu.dll from the avx2 folder)
                     // It can't be done automatically on Linux, because Linux uses the environment variable "LD_LIBRARY_PATH" to automatically load dependencies, and LD_LIBRARY_PATH can only be

--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -43,35 +43,81 @@ namespace LLama.Native
                 
                 foreach (var path in paths)
                 {
-                    Log($"Got relative library path '{path}' from local with {library.Metadata}, trying to load it...", LLamaLogLevel.Debug, config.LogCallback);
+                    // After the llama.cpp binaries have been split up (PR #10256), we need to load the dependencies manually.
+                    // It can't be done automatically on Windows, because the dependencies can be in different folders (for example, ggml-cuda.dll from the cuda12 folder, and ggml-cpu.dll from the avx2 folder)
+                    // It can't be done automatically on Linux, because Linux uses the environment variable "LD_LIBRARY_PATH" to automatically load dependencies, and LD_LIBRARY_PATH can only be
+                    // set before running LLamaSharp, but we only know which folders to search in when running LLamaSharp (decided by the NativeLibrary).
                     
-                    // If we are on Linux / OSX, we need to manually load the GGML dependency
-                    if (systemInfo.OSPlatform == OSPlatform.Linux || systemInfo.OSPlatform == OSPlatform.OSX)
+                    // Get the directory of the current runtime
+                    string? currentRuntimeDirectory = Path.GetDirectoryName(path);
+
+                    // If we failed to get the directory of the current runtime, log it and continue on to the next library
+                    if (currentRuntimeDirectory == null)
                     {
-                        // Get the directory of the library
-                        string? libraryDirectory = Path.GetDirectoryName(path);
-                        
-                        if (libraryDirectory != null)
+                        Log($"Failed to get the directory of the current runtime from path '{path}'", LLamaLogLevel.Error, config.LogCallback);
+                        continue;
+                    }
+
+                    // List which will hold all paths to dependencies to load
+                    var dependencyPaths = new List<string>();
+                    
+                    // We should always load ggml-base from the current runtime directory
+                    dependencyPaths.Add(Path.Combine(currentRuntimeDirectory, $"{libPrefix}ggml-base{ext}"));
+
+                    // If the library has metadata, we can check if we need to load additional dependencies
+                    if (library.Metadata != null)
+                    {
+                        if (systemInfo.OSPlatform == OSPlatform.OSX)
                         {
-                            // Construct the dependency (libggml) path
-                            string dependencyPath = Path.Combine(libraryDirectory, $"{libPrefix}ggml{ext}");
-                        
-                            // Try to load the dependency
-                            var dependencyResult = TryLoad(dependencyPath, description.SearchDirectories, config.LogCallback);
-                        
-                            // If we successfully loaded the library, log it
-                            if (dependencyResult != IntPtr.Zero)
-                            {
-                                Log($"Successfully loaded dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
-                            }
-                            else
-                            {
-                                Log($"Failed loading dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
-                            }
+                            // // ggml-metal (uncomment if needed, requires testing)
+                            // if (os == "osx-arm64")
+                            //     dependencyPaths.Add(Path.Combine(currentRuntimeDirectory, $"{libPrefix}ggml-metal{ext}"));
+                            
+                            // ggml-cpu
+                            // On OSX, we should load the CPU backend from the current directory
+                            dependencyPaths.Add(Path.Combine(currentRuntimeDirectory, $"{libPrefix}ggml-cpu{ext}"));
+                        }
+                        else
+                        {
+                            // ggml-cuda
+                            if (library.Metadata.UseCuda)
+                                dependencyPaths.Add(Path.Combine(currentRuntimeDirectory, $"{libPrefix}ggml-cuda{ext}"));
+                    
+                            // ggml-vulkan
+                            if (library.Metadata.UseVulkan)
+                                dependencyPaths.Add(Path.Combine(currentRuntimeDirectory, $"{libPrefix}ggml-vulkan{ext}"));
+                            
+                            // ggml-cpu
+                            // On other platforms (Windows, Linux), we need to load the CPU backend from the specified AVX level directory
+                            // We are using the AVX level supplied by NativeLibraryConfig, which automatically detects the highest supported AVX level for us
+                            dependencyPaths.Add(Path.Combine(
+                                $"runtimes/{os}/native/{NativeLibraryConfig.AvxLevelToString(library.Metadata.AvxLevel)}",
+                                $"{libPrefix}ggml-cpu{ext}"
+                            ));
                         }
                     }
                     
-                    // Try to load the library
+                    // And finally, we can add ggml
+                    dependencyPaths.Add(Path.Combine(currentRuntimeDirectory, $"{libPrefix}ggml{ext}"));
+                    
+                    // Now, we will loop through our dependencyPaths and try to load them one by one
+                    foreach (var dependencyPath in dependencyPaths)
+                    {
+                        // Try to load the dependency
+                        var dependencyResult = TryLoad(dependencyPath, description.SearchDirectories, config.LogCallback);
+                        
+                        // If we successfully loaded the library, log it
+                        if (dependencyResult != IntPtr.Zero)
+                        {
+                            Log($"Successfully loaded dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
+                        }
+                        else
+                        {
+                            Log($"Failed loading dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
+                        }
+                    }
+                    
+                    // Try to load the main library
                     var result = TryLoad(path, description.SearchDirectories, config.LogCallback);
                     
                     // If we successfully loaded the library, return the handle


### PR DESCRIPTION
This PR updates martindevans:wip_december_update to be compatible with llama.cpp backend/runtime split introduced in llama.cpp PR #10256.

Testing on OSX is still needed. In case the metal backend is not loading automatically, I left a fix (commented out) in place (NativeLibraryUtils.cs line 74-76) that should fix the issue. If metal does load automatically, we can simply remove those lines before merging.

Tests are now successfully passing on:

- Windows CUDA
- Linux CUDA