### PR TITLE
Grammar optimization modes

### DIFF
--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -114,7 +114,7 @@ public sealed class DefaultSamplingPipeline
     public uint Seed { get; set; } = GetRandomSeed();
     
     /// <summary>
-    /// Selected grammar optimization mode for processing
+    /// Selected grammar optimization mode
     /// </summary>
     public GrammarOptimizationMode GrammarOptimization { get; init; } = GrammarOptimizationMode.None;
 

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -221,30 +221,75 @@ public sealed class DefaultSamplingPipeline
         // Rent some buffers to use later
         var rentedBufferVocabSize = ArrayPool<LLamaTokenData>.Shared.Rent(ctx.ModelHandle.Vocab.Count);
         var rentedBufferSingleItem = ArrayPool<LLamaTokenData>.Shared.Rent(1);
+        
         try
         {
-            using (LLamaTokenDataArrayNative.Create(LLamaTokenDataArray.Create(ctx.GetLogitsIth(index), rentedBufferVocabSize), out var nativeAll))
+            // Handle grammar optimization modes
+            if (GrammarOptimization != GrammarOptimizationMode.None)
             {
-                // Apply the chain without the grammar to select one token which may or may not be valid
-                Apply(ctx, ref nativeAll);
-                var candidateToken = nativeAll.Data[checked((int)nativeAll.Selected)].ID;
-
-                // Now create another token data array with just that one token
-                rentedBufferSingleItem[0] = new LLamaTokenData(candidateToken, 1, 0);
-                using (LLamaTokenDataArrayNative.Create(new LLamaTokenDataArray(rentedBufferSingleItem, true), out var nativeSingleCandidate))
+                // Basic optimization : Apply the grammar to the selected token and check if it's valid
+                using (LLamaTokenDataArrayNative.Create(LLamaTokenDataArray.Create(ctx.GetLogitsIth(index), rentedBufferVocabSize), out var nativeAll))
                 {
-                    // Apply the grammar to this single candidate.
-                    _grammarChain.Apply(ref nativeSingleCandidate);
+                    // Apply the chain without the grammar to select one token which may or may not be valid
+                    Apply(ctx, ref nativeAll);
+                    
+                    // Select the candidate token
+                    var candidateToken = nativeAll.Data[checked((int)nativeAll.Selected)].ID;
 
-                    // Test if that single token was rejected by the grammar
-                    if (!float.IsNegativeInfinity(nativeSingleCandidate.Data[0].Logit))
+                    // Now create another token data array with just that one token
+                    rentedBufferSingleItem[0] = new LLamaTokenData(candidateToken, 1, 0);
+                    using (LLamaTokenDataArrayNative.Create(new LLamaTokenDataArray(rentedBufferSingleItem, true), out var nativeSingleCandidate))
                     {
-                        Accept(candidateToken);
-                        return candidateToken;
+                        // Apply the grammar chain to the single candidate
+                        _grammarChain.Apply(ref nativeSingleCandidate);
+
+                        // Check if the token passes the grammar
+                        if (!float.IsNegativeInfinity(nativeSingleCandidate.Data[0].Logit))
+                        {
+                            Accept(candidateToken);
+                            return candidateToken;
+                        }
+                    }
+                    
+                    // Extended optimization : Apply the grammar to the TopK tokens and check if the selected token is valid
+                    if (GrammarOptimization == GrammarOptimizationMode.Extended)
+                    {
+                        // Calculate a safe TopK value
+                        int safeTopK = Math.Min(TopK, nativeAll.Data.Length);
+
+                        // Rent a buffer for the TopK candidates
+                        var rentedBufferTopK = ArrayPool<LLamaTokenData>.Shared.Rent(safeTopK);
+                        try
+                        {
+                            // Copy only the TopK tokens from the existing candidate pool to the new buffer
+                            nativeAll.Data.Slice(0, safeTopK).CopyTo(rentedBufferTopK.AsSpan(0, safeTopK));
+
+                            // Create a native array with the TopK tokens
+                            using (LLamaTokenDataArrayNative.Create(new LLamaTokenDataArray(rentedBufferTopK, true), out var nativeTopK))
+                            {
+                                // Apply the grammar chain to the TopK candidates
+                                _grammarChain.Apply(ref nativeTopK);
+                                
+                                // Select the candidate token
+                                var candidateTokenTopK = nativeTopK.Data[checked((int)nativeTopK.Selected)];
+                                
+                                // Check if the token passes the grammar
+                                if (!float.IsNegativeInfinity(candidateTokenTopK.Logit))
+                                {
+                                    // Accept and return the token
+                                    Accept(candidateTokenTopK.ID);
+                                    return candidateTokenTopK.ID;
+                                }
+                            }
+                        }
+                        finally
+                        {
+                            ArrayPool<LLamaTokenData>.Shared.Return(rentedBufferTopK);
+                        }
                     }
                 }
             }
-
+            
             // If we get here the grammar rejected the token
             using (LLamaTokenDataArrayNative.Create(LLamaTokenDataArray.Create(ctx.GetLogitsIth(index), rentedBufferVocabSize), out var nativeAll))
             {

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -112,6 +112,11 @@ public sealed class DefaultSamplingPipeline
     /// Seed to use for random sampling
     /// </summary>
     public uint Seed { get; set; } = GetRandomSeed();
+    
+    /// <summary>
+    /// Selected grammar optimization mode for processing
+    /// </summary>
+    public GrammarOptimizationMode GrammarOptimization { get; init; } = GrammarOptimizationMode.None;
 
     /// <summary>
     /// A chain with just the grammar
@@ -261,5 +266,26 @@ public sealed class DefaultSamplingPipeline
             ArrayPool<LLamaTokenData>.Shared.Return(rentedBufferVocabSize);
             ArrayPool<LLamaTokenData>.Shared.Return(rentedBufferSingleItem);
         }
+    }
+    
+    /// <summary>
+    /// Grammar Optimization Mode
+    /// </summary>
+    public enum GrammarOptimizationMode
+    {
+        /// <summary>
+        /// No grammar optimization, slow because it has to apply the grammar to the entire vocab.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Attempts to return early by only applying the grammar to the selected token and checking if it's valid.
+        /// </summary>
+        Basic,
+
+        /// <summary>
+        /// Attempts to return early by applying the grammar to the top K tokens and checking if the selected token is valid.
+        /// </summary>
+        Extended
     }
 }

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -163,7 +163,6 @@ public sealed class DefaultSamplingPipeline
 
         var chain = SafeLLamaSamplerChainHandle.Create(LLamaSamplerChainParams.Default());
         chain.AddGrammar(context.ModelHandle, Grammar.Gbnf, Grammar.Root);
-        chain.AddDistributionSampler(Seed);
         return chain;
     }
 


### PR DESCRIPTION
- Adds `GrammarOptimizationMode`

The `GrammarOptimizationMode` can now be selected in the `DefaultSamplingPipeline`.

**GrammarOptimizationMode.None**
No grammar optimization, slow because it has to apply the grammar to the entire vocab.

**GrammarOptimizationMode.Basic**
Attempts to return early by only applying the grammar to the selected token and checking if it's valid.

**GrammarOptimizationMode.Extended**
Attempts to return early by applying the grammar to the top K tokens and checking if the selected token is valid.

Every optimization (including `Basic`) that applies the grammar at the end instead of the beginning of the chain, is a possible degradation in output quality.

If the model is finetuned on the grammar, both the output quality and performance gains from the optimizations will improve.

- Currently, if set to `Extended`, `Basic` will always be attempted first, I'm not sure if this is desired (due to the high success rate of the `Basic` option, it was worth it in my use case)
